### PR TITLE
Ask for the visitor's name before asking who they are looking for

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - SupportKit (2.7.2)
+  - SupportKit (2.8.1)
 
 DEPENDENCIES:
   - SupportKit
 
 SPEC CHECKSUMS:
-  SupportKit: d467d81d430ac01304f7e3b2668748126b84e0d0
+  SupportKit: bed84bbc4495681f044be7904e607c5313acb3f8
 
-COCOAPODS: 0.36.3
+COCOAPODS: 0.37.2

--- a/ReceptionKit/Base.lproj/Main.storyboard
+++ b/ReceptionKit/Base.lproj/Main.storyboard
@@ -180,6 +180,7 @@
         <!--Visitor Search Results Table View Controller-->
         <scene sceneID="lBv-8K-TaT">
             <objects>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="PdX-Nl-x6B" userLabel="First Responder" sceneMemberID="firstResponder"/>
                 <tableViewController id="yze-Re-wJM" customClass="VisitorSearchResultsTableViewController" customModule="ReceptionKit" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="100" sectionHeaderHeight="22" sectionFooterHeight="22" id="j3x-oo-KLf">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="536"/>
@@ -235,14 +236,11 @@
                             <outlet property="delegate" destination="yze-Re-wJM" id="WAc-vS-Fmy"/>
                         </connections>
                     </tableView>
-                    <navigationItem key="navigationItem" id="kDW-4E-aaV">
-                        <barButtonItem key="rightBarButtonItem" style="done" systemItem="done" id="xT2-3J-o2g"/>
-                    </navigationItem>
+                    <navigationItem key="navigationItem" id="kDW-4E-aaV"/>
                     <connections>
                         <segue destination="XcS-0N-QxK" kind="show" identifier="SelectedContact" id="qXu-7C-vqp"/>
                     </connections>
                 </tableViewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="PdX-Nl-x6B" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="2579" y="1915"/>
         </scene>
@@ -520,6 +518,6 @@
         <image name="IconDeliveryUPS" width="400" height="400"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="Uts-8T-2PH"/>
+        <segue reference="qXu-7C-vqp"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/ReceptionKit/Base.lproj/Main.storyboard
+++ b/ReceptionKit/Base.lproj/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="IaD-hP-Gwr">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="IaD-hP-Gwr">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
@@ -38,7 +38,7 @@
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
                                 <connections>
-                                    <segue destination="Jco-hV-A70" kind="show" id="uTC-Jq-Q2g"/>
+                                    <segue destination="3Yy-Wq-cJ7" kind="show" id="vVh-Fq-cLT"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -92,7 +92,7 @@
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
                                 <connections>
-                                    <segue destination="gmm-f4-xMQ" kind="show" id="ySL-3K-ifk"/>
+                                    <segue destination="gmm-f4-xMQ" kind="show" identifier="" id="ySL-3K-ifk"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="dRx-RZ-T6n">
@@ -104,7 +104,7 @@
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
                                 <connections>
-                                    <segue destination="3Yy-Wq-cJ7" kind="show" id="GYv-TI-Pgt"/>
+                                    <segue destination="XcS-0N-QxK" kind="show" identifier="" id="Uts-8T-2PH"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -127,7 +127,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="yCp-eU-JQ8" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1252" y="1131"/>
+            <point key="canvasLocation" x="1252" y="1915"/>
         </scene>
         <!--Visitor Search View Controller-->
         <scene sceneID="aic-cW-JLl">
@@ -142,7 +142,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="The Wonderful Wizard of Oz" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="Ol3-q4-HxX">
-                                <rect key="frame" x="16" y="168" width="568" height="60"/>
+                                <rect key="frame" x="16" y="167.5" width="568" height="60"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="60" id="RNk-Kc-UUe"/>
                                 </constraints>
@@ -150,7 +150,7 @@
                                 <textInputTraits key="textInputTraits" autocapitalizationType="words" autocorrectionType="no" spellCheckingType="no" returnKeyType="search"/>
                             </textField>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Who are you looking for?" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WSU-lu-VD8">
-                                <rect key="frame" x="16" y="120" width="568" height="32"/>
+                                <rect key="frame" x="16" y="120" width="568" height="31.5"/>
                                 <fontDescription key="fontDescription" name="Futura-Medium" family="Futura" pointSize="24"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
@@ -170,12 +170,12 @@
                         <outlet property="lookingForLabel" destination="WSU-lu-VD8" id="bS0-4Q-0lN"/>
                         <outlet property="nameTextField" destination="Ol3-q4-HxX" id="GRt-VE-ooX"/>
                         <segue destination="yze-Re-wJM" kind="show" identifier="VisitorNameSearchSegue" id="IB9-oJ-9xM"/>
-                        <segue destination="3Yy-Wq-cJ7" kind="show" identifier="VisitorNameInvalidSearchSegue" id="i9k-c0-eZo"/>
+                        <segue destination="XcS-0N-QxK" kind="show" identifier="VisitorNameInvalidSearchSegue" id="gFX-Oy-Kkb"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="mDu-fM-8Fz" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1252" y="1823"/>
+            <point key="canvasLocation" x="1922" y="1915"/>
         </scene>
         <!--Visitor Search Results Table View Controller-->
         <scene sceneID="lBv-8K-TaT">
@@ -204,7 +204,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="(123) 456 - 7890" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7vd-6a-2Zf">
-                                            <rect key="frame" x="131" y="56" width="461" height="21"/>
+                                            <rect key="frame" x="131" y="56.5" width="461" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                             <nil key="highlightedColor"/>
@@ -244,7 +244,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="PdX-Nl-x6B" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1922" y="1823"/>
+            <point key="canvasLocation" x="2579" y="1915"/>
         </scene>
         <!--Delivery Company View Controller-->
         <scene sceneID="gh1-uv-ZGA">
@@ -435,7 +435,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="q0Q-QB-EVl" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3309" y="789"/>
+            <point key="canvasLocation" x="2579" y="1177"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="TmD-pg-Dto">
@@ -473,7 +473,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="Barack Obama" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="dbb-CH-MQ3">
-                                <rect key="frame" x="16" y="168" width="568" height="60"/>
+                                <rect key="frame" x="16" y="167" width="568" height="60"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="60" id="d7u-fz-Qya"/>
                                 </constraints>
@@ -481,7 +481,7 @@
                                 <textInputTraits key="textInputTraits" autocapitalizationType="words" autocorrectionType="no" spellCheckingType="no" keyboardType="namePhonePad" returnKeyType="go"/>
                             </textField>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="What is your name?" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TCf-HB-Rk0">
-                                <rect key="frame" x="16" y="120" width="568" height="32"/>
+                                <rect key="frame" x="16" y="120" width="568" height="31.5"/>
                                 <fontDescription key="fontDescription" name="Futura-Medium" family="Futura" pointSize="24"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
@@ -500,12 +500,12 @@
                     <connections>
                         <outlet property="nameTextField" destination="dbb-CH-MQ3" id="COK-xX-CbT"/>
                         <outlet property="yourNameLabel" destination="TCf-HB-Rk0" id="YdR-ZG-n1e"/>
-                        <segue destination="XcS-0N-QxK" kind="show" identifier="VisitorNameSetSegue" id="MAi-B6-dIM"/>
+                        <segue destination="Jco-hV-A70" kind="show" identifier="VisitorEnteredNameSegue" id="3KN-I9-G1D"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="0e4-xI-OQV" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1922" y="1131"/>
+            <point key="canvasLocation" x="1252" y="1177"/>
         </scene>
     </scenes>
     <resources>
@@ -520,7 +520,6 @@
         <image name="IconDeliveryUPS" width="400" height="400"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="i9k-c0-eZo"/>
-        <segue reference="MAi-B6-dIM"/>
+        <segue reference="Uts-8T-2PH"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/ReceptionKit/View Controllers/Visitor/VisitorAskNameViewController.swift
+++ b/ReceptionKit/View Controllers/Visitor/VisitorAskNameViewController.swift
@@ -13,7 +13,7 @@ class VisitorAskNameViewController: ReturnToHomeViewController, UITextFieldDeleg
     @IBOutlet weak var yourNameLabel: UILabel!
     @IBOutlet weak var nameTextField: UITextField!
 
-    let visitorNameSetSegue = "VisitorNameSetSegue"
+    let visitorEnteredNameSegue = "VisitorEnteredNameSegue"
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -36,15 +36,22 @@ class VisitorAskNameViewController: ReturnToHomeViewController, UITextFieldDeleg
     // MARK: - UITextViewDelegate
     //
     
+    // Segue to the VisitorViewController when the name is entered
     func textFieldShouldReturn(textField: UITextField) -> Bool {
-        let enteredName = nameTextField.text
-        if enteredName == "" {
-            sendMessage("Someone is at the reception!")
-        } else {
-            sendMessage(nameTextField.text + " is at the reception!")
-        }
-        performSegueWithIdentifier(visitorNameSetSegue, sender: self)
+        performSegueWithIdentifier(visitorEnteredNameSegue, sender: self)
         return false
+    }
+    
+    
+    //
+    // MARK: - Navigation
+    //
+    
+    // Set the visitor's name before the segue
+    override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
+        if let visitorViewController = segue.destinationViewController as? VisitorViewController {
+            visitorViewController.visitorName = nameTextField.text
+        }
     }
     
 }

--- a/ReceptionKit/View Controllers/Visitor/VisitorSearchResultsTableViewController.swift
+++ b/ReceptionKit/View Controllers/Visitor/VisitorSearchResultsTableViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 
 class VisitorSearchResultsTableViewController: ReturnToHomeTableViewController {
 
+    var visitorName: String?
     var searchQuery: String?
     var searchResults: [Contact]?
     
@@ -52,7 +53,11 @@ class VisitorSearchResultsTableViewController: ReturnToHomeTableViewController {
     
     override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         let contact = searchResults![indexPath.row]
-        sendMessage("Someone is at the reception looking for \(contact.name)")
+        if visitorName == nil || visitorName == "" {
+            sendMessage("Someone is at the reception looking for \(contact.name)!")
+        } else {
+            sendMessage("\(visitorName!) is at the reception looking for \(contact.name)!")
+        }
         performSegueWithIdentifier("SelectedContact", sender: self)
     }
     

--- a/ReceptionKit/View Controllers/Visitor/VisitorSearchViewController.swift
+++ b/ReceptionKit/View Controllers/Visitor/VisitorSearchViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 
 class VisitorSearchViewController: ReturnToHomeViewController, UITextFieldDelegate {
 
+    var visitorName: String?
     var searchResults = [Contact]()
     
     @IBOutlet weak var lookingForLabel: UILabel!
@@ -40,6 +41,7 @@ class VisitorSearchViewController: ReturnToHomeViewController, UITextFieldDelega
     func textFieldShouldReturn(textField: UITextField) -> Bool {
         searchResults = Contact.search(nameTextField.text)
 
+        // Check if the person the visitor is searching for exists
         if searchResults.count > 0 {
             performSegueWithIdentifier("VisitorNameSearchSegue", sender: self)
         } else {
@@ -54,13 +56,21 @@ class VisitorSearchViewController: ReturnToHomeViewController, UITextFieldDelega
     // MARK: - Navigation
     //
 
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    // Post a message if the person the visitor is looking for does not exist
+    // Otherwise show the result of the search
     override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
-        // Get the new view controller using segue.destinationViewController.
-        // Pass the selected object to the new view controller.
         if let visitorSearchResultsTableViewController = segue.destinationViewController as? VisitorSearchResultsTableViewController {
+            // Exists
+            visitorSearchResultsTableViewController.visitorName = visitorName
             visitorSearchResultsTableViewController.searchQuery = nameTextField.text
             visitorSearchResultsTableViewController.searchResults = searchResults
+        } else if let waitingViewController = segue.destinationViewController as? WaitingViewController {
+            // Does not exist
+            if visitorName == nil || visitorName == "" {
+                sendMessage("Someone is at the reception looking for \(nameTextField.text)!")
+            } else {
+                sendMessage("\(visitorName!) is at the reception looking for \(nameTextField.text)!")
+            }
         }
     }
 

--- a/ReceptionKit/View Controllers/Visitor/VisitorViewController.swift
+++ b/ReceptionKit/View Controllers/Visitor/VisitorViewController.swift
@@ -10,6 +10,9 @@ import UIKit
 
 class VisitorViewController: ReturnToHomeViewController {
     
+    // Name of the visitor set by VisitorAskNameViewController
+    var visitorName: String?
+    
     @IBOutlet weak var knowButton: UIButton!
     @IBOutlet weak var notKnowButton: UIButton!
     
@@ -21,10 +24,28 @@ class VisitorViewController: ReturnToHomeViewController {
         notKnowButton.setTitle(Text.get("i don't know"), forState: UIControlState.Normal)
     }
     
+    // Centre align the button text - left-aligned by default
     override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
-        
         knowButton.titleLabel?.textAlignment = NSTextAlignment.Center
+    }
+    
+    
+    //
+    // MARK: - Navigation
+    //
+    
+    // Should post message if the visitor does not know who they are looking for
+    override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
+        if let waitingViewController = segue.destinationViewController as? WaitingViewController {
+            if visitorName == nil || visitorName == "" {
+                sendMessage("Someone is at the reception!")
+            } else {
+                sendMessage("\(visitorName!) is at the reception!")
+            }
+        } else if let visitorSearchViewController = segue.destinationViewController as? VisitorSearchViewController {
+            visitorSearchViewController.visitorName = visitorName
+        }
     }
 
 }


### PR DESCRIPTION
Addresses https://github.com/AcroMace/receptionkit/issues/1.

Now when the visitor taps `i'm a visitor`, the app will prompt the visitor for their name before giving them the option to choose between searching for a contact or selecting `i don't know`. Both of these options should now send the visitor's name to Slack.

Also updated SupportKit and deleted a useless "Done" button in search.
